### PR TITLE
Update how_to_setup_and_train_kor.md

### DIFF
--- a/how_to_setup_and_train_kor.md
+++ b/how_to_setup_and_train_kor.md
@@ -21,7 +21,7 @@
 #### 새로운 Conda 환경 만들기 및 종속성 설치
 새로운 Conda 환경을 만들고 필요한 종속성을 설치하려면 다음 명령어를 사용합니다.
 
-```conda env create -n myenv python=3.10 --file requirements.yml```
+```conda env create -n myenv --file requirements.yml```
 
 이 명령어는 새로운 Conda 환경 'myenv'를 만들고 requirements.yml 파일에 지정된 모든 종속성을 설치합니다. CUDA, PyTorch, Torchvision, PyTorch-Lightning, Ray 및 WandB가 포함됩니다.
 


### PR DESCRIPTION
conda env create 명령어에서 Python 버전은 환경 파일(requirements.yml) 내에서 설정되며, 명령어 자체에서 Python 버전을 지정하지 않아야 됩니다.

## Overview
- 가상환경을 만들 때 종속성 설치 명령어

## Change Log
-`conda env create -n myenv python=3.10 --file requirements.yml` 에서 `conda env create -n myenv --file requirements.yml`로 변경

## To Reviewer
-conda env create 명령어에서 Python 버전은 환경 파일(requirements.yml) 내에서 설정되어 있어서,
 명령어 자체에서 Python 버전을 지정하지 않아도 될 것 같습니다

## Issue Tags
- Closed | Fixed: #22 
- See also: #22 